### PR TITLE
Remove default exception handling

### DIFF
--- a/CliToolkit.TestApp/ApplicationRoot.cs
+++ b/CliToolkit.TestApp/ApplicationRoot.cs
@@ -15,14 +15,8 @@ namespace CliToolkit.TestApp
         [CliDescription("Example of common help paramater parsing")]
         public DefaultHelpMenuCommand HelpMenuCommand { get; set; }
 
-        [CliDescription("Give me a string!")]
-        public string StringValue { get; set; }
-
-        [CliDescription("Give me an int!")]
-        public int IntValue { get; set; }
-
-        [CliDescription("Give me a bool!")]
-        public bool BoolValue { get; set; }
+        [CliDescription("Show detected configuration variables")]
+        public ConfigurationValueCommand ConfigCommand { get; set;}
 
         protected override void OnExecute(string[] args)
         {

--- a/CliToolkit.TestApp/Commands/ConfigurationValueCommand.cs
+++ b/CliToolkit.TestApp/Commands/ConfigurationValueCommand.cs
@@ -1,10 +1,23 @@
-﻿namespace CliToolkit.TestApp.Commands
+﻿using System;
+
+namespace CliToolkit.TestApp.Commands
 {
     public class ConfigurationValueCommand : CliCommand
     {
+        [CliDescription("Give me a string!")]
+        public string StringValue { get; set; }
+
+        [CliDescription("Give me an int!")]
+        public int IntValue { get; set; }
+
+        [CliDescription("Give me a bool!")]
+        public bool BoolValue { get; set; }
+
         protected override void OnExecute(string[] args)
         {
-            throw new System.NotImplementedException();
+            Console.WriteLine($"{nameof(StringValue)}: {StringValue}");
+            Console.WriteLine($"{nameof(IntValue)}: {IntValue}");
+            Console.WriteLine($"{nameof(BoolValue)}: {BoolValue}");
         }
     }
 }

--- a/CliToolkit.TestApp/Commands/RuntimeErrorCommand.cs
+++ b/CliToolkit.TestApp/Commands/RuntimeErrorCommand.cs
@@ -2,15 +2,14 @@
 
 namespace CliToolkit.TestApp.Commands
 {
-    [CliNamespace("CoolGuy")]
     public class RuntimeErrorCommand : CliCommand
     {
         [CliDescription("Don't try it!")]
-        public bool IgnoreErrorFlag { get; set; }
+        public bool IgnoreError { get; set; }
 
         protected override void OnExecute(string[] args)
         {
-            if (!IgnoreErrorFlag)
+            if (!IgnoreError)
             {
                 throw new NotImplementedException();
             }

--- a/CliToolkit.TestApp/appsettings.json
+++ b/CliToolkit.TestApp/appsettings.json
@@ -1,8 +1,10 @@
 {
-  "StringValue": "Wow!",
-  "IntValue": 42,
-  "BoolValue": true,
-  "CoolGuy": {
+  "RunTimeError": {
     "IgnoreErrorFlag": true
+  },
+  "ConfigurationValue": {
+    "StringValue": "Wow!",
+    "IntValue": 42,
+    "BoolValue": true
   }
 }

--- a/CliToolkit.Tests/ConfigrationValueTests.cs
+++ b/CliToolkit.Tests/ConfigrationValueTests.cs
@@ -1,0 +1,21 @@
+﻿using CliToolkit.TestApp;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace CliToolkit.Tests
+{
+    public class ConfigrationValueTests
+    {
+        [Fact]
+        public void DefaultActionTest()
+        {
+            var app = new CliAppBuilder<ApplicationRoot>()
+                .Configure(c => c.AddJsonFile("appsettings.json"))
+                .Start(new[] { "config" });
+
+            Assert.Equal("Wow!", app.ConfigCommand.StringValue);
+            Assert.Equal(42, app.ConfigCommand.IntValue);
+            Assert.True(app.ConfigCommand.BoolValue);
+        }
+    }
+}

--- a/CliToolkit.Tests/RuntimeErrorTests.cs
+++ b/CliToolkit.Tests/RuntimeErrorTests.cs
@@ -1,6 +1,4 @@
 using CliToolkit.TestApp;
-using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestPlatform.TestHost;
 using System;
 using Xunit;
 
@@ -9,14 +7,22 @@ namespace CliToolkit.Tests
     public class RuntimeErrorTests
     {
         [Fact]
-        public void Test1()
+        public void DefaultActionTest()
         {
             var app = new CliAppBuilder<ApplicationRoot>()
-                .Configure(c => c.AddJsonFile("appsettings.json"))
-                //.RegisterServices(RegisterServices)
-                .Start(new[] { "error" });
+                .Build();
+
+            Assert.ThrowsAny<Exception>(() => app.Start(new[] { "error", "--ignore-error=false" }));
+        }
+
+        [Fact]
+        public void IgnoreErrorFlagTest()
+        {
+            var app = new CliAppBuilder<ApplicationRoot>()
+                .Start(new[] { "error", "--ignore-error=true" });
 
             Assert.NotNull(app.ErrorCommand);
+            Assert.True(app.ErrorCommand.IgnoreError) ;
         }
     }
 }

--- a/CliToolkit/CliApp.cs
+++ b/CliToolkit/CliApp.cs
@@ -9,23 +9,12 @@ namespace CliToolkit
     {
         public CliAppInfo AppInfo { get; } = new CliAppInfo();
 
-        public int Start(string[] args)
+        public void Start(string[] args)
         {
             try
             {
                 PrintHeader();
                 Parse(this, args);
-                return AppInfo.ExitCode = 0;
-            }
-            catch (Exception ex)
-            {
-                if (!string.IsNullOrEmpty(ex.Message))
-                {
-                    Console.WriteLine($"{Color.Red}{Format.Bold}{ex.Message}{Reset.All}");
-                }
-                var logger = AppInfo.ServiceCollection.BuildServiceProvider().GetService<ILogger>();
-                logger?.LogError(ex, ex.Message);
-                return AppInfo.ExitCode = 1;
             }
             finally
             {

--- a/CliToolkit/CliCommand.cs
+++ b/CliToolkit/CliCommand.cs
@@ -202,7 +202,7 @@ namespace CliToolkit
                     }
                     else
                     {
-                        section = newConfig.GetSection(_type.Name);
+                        section = newConfig.GetSection(TextHelper.TrimCommandSuffix(_type.Name));
                     }
                 }
                 else if (string.IsNullOrEmpty(_namespaceAttribute.Namespace))


### PR DESCRIPTION
This is something that is more useful for the library consumer to implement. Exceptions were being completely swallowed.